### PR TITLE
Addition of quick-fix to stop international signups on PREDICT sign up page

### DIFF
--- a/_for-participants/Sign Up.md
+++ b/_for-participants/Sign Up.md
@@ -13,7 +13,13 @@ is not loading, you can fill it in <a href="https://form.gov.sg/61e8ac0f2ce86a00
 It will not be linked to the data you provide in the study should you
 participate in the study.
 
-<br>Thank you for your interest in participating in the PREDICT study. A member of our study team will contact you to arrange a screening session to confirm your eligibility.</p>
+**You will be eligible for the study if you:**
+* Are between 18 to 75 years old
+* Are a Singapore citizen or permanent resident
+* Can speak English, Chinese, Malay, or Tamil
+* Have no symptoms of depression OR have some symptoms of depression not amounting to major depressive disorder
+	
+Thank you for your interest in participating in the PREDICT study. A member of our study team will contact you to arrange a screening session to confirm your eligibility.</p>
 <div class="iframe-wrapper">
 <iframe style="width: 100%; height: 1700px" allowfullscreen="true" frameborder="0" src="https://form.gov.sg/61e8ac0f2ce86a0012869089"></iframe>
 </div>

--- a/_for-participants/Sign Up.md
+++ b/_for-participants/Sign Up.md
@@ -13,13 +13,24 @@ is not loading, you can fill it in <a href="https://form.gov.sg/61e8ac0f2ce86a00
 It will not be linked to the data you provide in the study should you
 participate in the study.
 
-**You will be eligible for the study if you:**
-* Are between 18 to 75 years old
-* Are a Singapore citizen or permanent resident
-* Can speak English, Chinese, Malay, or Tamil
-* Have no symptoms of depression OR have some symptoms of depression not amounting to major depressive disorder
-	
-Thank you for your interest in participating in the PREDICT study. A member of our study team will contact you to arrange a screening session to confirm your eligibility.</p>
+You will be eligible for the study if you:
+</p><ul data-tight="true" class="tight">
+<li>
+<p>Are between 18 to 75 years old</p>
+</li>
+<li>
+<p>Are a Singapore citizen or permanent resident</p>
+</li>
+<li>
+<p>Can speak English, Chinese, Malay, or Tamil</p>
+</li>
+<li>
+<p>Have no symptoms of depression OR have some symptoms of depression not amounting to major depressive disorder</p>
+</li>
+</ul>
+<p></p>
+
+Thank you for your interest in participating in the PREDICT study. A member of our study team will contact you to arrange a screening session to confirm your eligibility.<p></p>
 <div class="iframe-wrapper">
 <iframe style="width: 100%; height: 1700px" allowfullscreen="true" frameborder="0" src="https://form.gov.sg/61e8ac0f2ce86a0012869089"></iframe>
 </div>

--- a/_for-participants/Sign Up.md
+++ b/_for-participants/Sign Up.md
@@ -13,7 +13,7 @@ is not loading, you can fill it in <a href="https://form.gov.sg/61e8ac0f2ce86a00
 It will not be linked to the data you provide in the study should you
 participate in the study.
 
-You will be eligible for the study if you:
+</p><p>You will be eligible for the study if you:
 </p><ul data-tight="true" class="tight">
 <li>
 <p>Are between 18 to 75 years old</p>

--- a/_for-participants/Sign Up.md
+++ b/_for-participants/Sign Up.md
@@ -30,7 +30,7 @@ participate in the study.
 </ul>
 <p></p>
 
-Thank you for your interest in participating in the PREDICT study. A member of our study team will contact you to arrange a screening session to confirm your eligibility.<p></p>
+Thank you for your interest in participating in the PREDICT study. A member of our study team will contact you to arrange a screening session to confirm your eligibility.
 <div class="iframe-wrapper">
 <iframe style="width: 100%; height: 1700px" allowfullscreen="true" frameborder="0" src="https://form.gov.sg/61e8ac0f2ce86a0012869089"></iframe>
 </div>


### PR DESCRIPTION
A new paragraph has been added to the PREDICT sign up page above the registration form. This is a quick-fix to block international signups until the team can determine a more impactful solution. The paragraph states:

You will be eligible for the study if you:

- Are between 18 to 75 years old
- Are a Singapore citizen or permanent resident
- Can speak English, Chinese, Malay, or Tamil
- Have no symptoms of depression OR have some symptoms of depression not amounting to major depressive disorder

[Registration form here]